### PR TITLE
Ensure correct thread state on fork

### DIFF
--- a/lib/instrumental/agent.rb
+++ b/lib/instrumental/agent.rb
@@ -194,7 +194,7 @@ module Instrumental
     def stop
       disconnect
       if @thread
-        @thread.kill
+        @thread.kill.join
         @thread = nil
       end
     end

--- a/lib/instrumental/agent.rb
+++ b/lib/instrumental/agent.rb
@@ -443,7 +443,10 @@ module Instrumental
       case err
       when EOFError
         # nop
-      when Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      when Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::EADDRINUSE
+        # If the connection has been refused by Instrumental
+        # or we cannot reach the server
+        # or the connection state of this socket is in a race
         logger.error "unable to connect to Instrumental, hanging up with #{@queue.size} messages remaining"
         allow_reconnect = false
       else

--- a/lib/instrumental/agent.rb
+++ b/lib/instrumental/agent.rb
@@ -194,7 +194,7 @@ module Instrumental
     def stop
       disconnect
       if @thread
-        @thread.kill.join
+        @thread.kill
         @thread = nil
       end
     end

--- a/lib/instrumental/agent.rb
+++ b/lib/instrumental/agent.rb
@@ -375,9 +375,9 @@ module Instrumental
 
     def open_socket(sockaddr_in, secure, verify_cert)
       sock = Socket.new(Socket::PF_INET, Socket::SOCK_STREAM, 0)
-      sock.connect sockaddr_in
+      sock.connect(sockaddr_in)
       if secure
-        context = OpenSSL::SSL::SSLContext.new()
+        context = OpenSSL::SSL::SSLContext.new
         if verify_cert
           context.set_params(:verify_mode => OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT)
         else

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -387,6 +387,25 @@ shared_examples "Instrumental Agent" do
           agent.should_not be_running
           agent.queue.size.should == 1
         end
+
+        it "should cancel the worker thread when the host has hung up" do
+          agent.gauge('connection_failure', 1, 1234)
+          wait
+          server.stop
+          wait
+          agent.gauge('connection_failure', 1, 1234)
+          wait
+          agent.should_not be_running
+          agent.queue.size.should == 1
+          wait
+          server.listen
+          wait
+          agent.gauge('connection_failure', 1, 1234)
+          wait
+          agent.should be_running
+          agent.queue.size.should == 0
+        end
+
       end
 
 


### PR DESCRIPTION
In certain cases where the Agent worker thread has been activated, and the process wherein it was activated calls `fork`, the worker thread may be in the middle of a `getaddrinfo` call that is in a critical section of an OS level mutex. This mutex state gets transmitted to the child process in an inconsistent state, causing a situation where, if the forked child attempts to call `getaddrinfo`, it attempts to lock on the OS level mutex which has been set to "locked" in the parent process and will never unlock. 

This PR moves the resolution out to the main thread ( the thread creating the agent worker thread ), such that the caller has more control over the interaction w/ `fork`.  