### PR TITLE
Disconnect cannot crash

### DIFF
--- a/lib/instrumental/agent.rb
+++ b/lib/instrumental/agent.rb
@@ -513,6 +513,9 @@ module Instrumental
         end
         @socket.close
       end
+    rescue Exception => e
+      logger.error "Error closing socket, #{e.message}"
+    ensure
       @socket = nil
     end
 

--- a/lib/instrumental/agent.rb
+++ b/lib/instrumental/agent.rb
@@ -499,6 +499,8 @@ module Instrumental
 
     def flush_socket(socket)
       socket.flush
+    rescue Exception => e
+      logger.error "Error flushing socket, #{e.message}"
     end
 
     def disconnect


### PR DESCRIPTION
Exceptions in the disconnect process should not cause bad agent state to occur