### PR TITLE
Consistent DNS test pass/fail

### DIFF
--- a/instrumental_agent.gemspec
+++ b/instrumental_agent.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.add_development_dependency("pry", [">= 0"])
   s.add_development_dependency("rake", [">= 0"])
   s.add_development_dependency("rspec", ["~> 3.0"])
   s.add_development_dependency("fuubar", [">= 0"])

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -358,12 +358,11 @@ shared_examples "Instrumental Agent" do
       end
 
       context 'bad address' do
-        let(:address) { "nope:9999" }
+        let(:address) { "bad-address:9999" }
 
         it "should not be running if it cannot connect" do
+          expect(Resolv).to receive(:getaddresses).with("bad-address").and_raise Resolv::ResolvError
           agent.gauge('connection_test', 1, 1234)
-          # nope:9999 does not resolve to anything, the agent will not resolve
-          # the address and refuse to start a worker thread
           expect(agent.send(:running?)).to eq(false)
         end
       end


### PR DESCRIPTION
Local DNS sometimes provides catch-all resolution which let's even incorrect addresses like `"nope"` (previously used in tests) to sometimes resolve. Instead let's override resolution and force failure to make this consistent.